### PR TITLE
Change generation destination to hlf

### DIFF
--- a/docs/content/labs/iou-smart-app.md
+++ b/docs/content/labs/iou-smart-app.md
@@ -121,7 +121,7 @@ In this step, we will implement the 4 transactions defined in the smart contract
 ## 5. Generate Blockchain Artifacts
 
 ### *5.1 Hyperledger Fabric*
-Run following command from tutorial directory Hyperledger Fabric chaincode is written to tutorial/artifacts/hlf folder
+Run following command from tutorial directory Hyperledger Fabric chaincode is written to tutorial/artifacts/iou folder
 
 For testing, transaction security support is not enabled.
 


### PR DESCRIPTION
Made changes on (https://github.com/TIBCOSoftware/dovetail-cli/pull/25) so the generation uses the json file name to create the destination folder instead of hard coding hlf.

Changed the docs here to reflect those changes